### PR TITLE
feat: show circulating supply % and burn amount on stake page

### DIFF
--- a/packages/nextjs/app/stake/page.tsx
+++ b/packages/nextjs/app/stake/page.tsx
@@ -14,6 +14,7 @@ import {
   useTargetNetwork,
 } from "~~/hooks/scaffold-eth";
 
+const BURN_ADDRESS = "0x000000000000000000000000000000000000dEaD" as const;
 const CLAWD_ETH_POOL = "0xCD55381a53da35Ab1D7Bc5e3fE5F76cac976FAc3" as const;
 const WETH_BASE = "0x4200000000000000000000000000000000000006";
 const POOL_ABI = [
@@ -84,6 +85,17 @@ const StakePage: NextPage = () => {
     watch: true,
   });
 
+  const { data: clawdTotalSupply } = useScaffoldReadContract({
+    contractName: "MockCLAWD",
+    functionName: "totalSupply",
+  });
+
+  const { data: burnBalance } = useScaffoldReadContract({
+    contractName: "MockCLAWD",
+    functionName: "balanceOf",
+    args: [BURN_ADDRESS],
+  });
+
   const { data: activeStakesData } = useScaffoldReadContract({
     contractName: "ClawdVictionStaking",
     functionName: "getActiveStakes",
@@ -109,6 +121,22 @@ const StakePage: NextPage = () => {
       return null;
     }
   }, [slot0Data, token0Data, ethPrice]);
+
+  // Circulating supply & staked percentage
+  const { stakedPct, burnedFormatted } = useMemo(() => {
+    if (!clawdTotalSupply || !burnBalance || !totalSupplyStaked) {
+      return { stakedPct: null, burnedFormatted: null };
+    }
+    const circulating = clawdTotalSupply - burnBalance;
+    const pct =
+      circulating > 0n ? (Number(formatEther(totalSupplyStaked)) / Number(formatEther(circulating))) * 100 : 0;
+    const burnedNum = Number(formatEther(burnBalance));
+    let burned: string;
+    if (burnedNum >= 1_000_000_000) burned = `${(burnedNum / 1_000_000_000).toFixed(2)}B`;
+    else if (burnedNum >= 1_000_000) burned = `${(burnedNum / 1_000_000).toFixed(2)}M`;
+    else burned = burnedNum.toLocaleString();
+    return { stakedPct: pct, burnedFormatted: burned };
+  }, [clawdTotalSupply, burnBalance, totalSupplyStaked]);
 
   // Write hooks - SEPARATE for each action
   const { writeContractAsync: approveWrite, isMining: isApproving } = useScaffoldWriteContract("MockCLAWD");
@@ -360,7 +388,11 @@ const StakePage: NextPage = () => {
         </div>
         <div className="stat bg-base-200 rounded-none shadow">
           <div className="stat-title">Total Staked (All)</div>
-          <div className="stat-value text-2xl">{totalSupplyStaked ? formatClawd(totalSupplyStaked) : "0"}</div>
+          <div className="stat-value text-2xl">
+            {totalSupplyStaked ? formatClawd(totalSupplyStaked) : "0"}
+            {stakedPct !== null && <span className="text-lg text-base-content/70 ml-1">({stakedPct.toFixed(1)}%)</span>}
+          </div>
+          {burnedFormatted && <div className="stat-desc">🔥 {burnedFormatted} burned</div>}
         </div>
       </div>
 

--- a/packages/nextjs/contracts/deployedContracts.ts
+++ b/packages/nextjs/contracts/deployedContracts.ts
@@ -449,6 +449,13 @@ const deployedContracts = {
           stateMutability: "nonpayable",
           type: "function",
         },
+        {
+          inputs: [],
+          name: "totalSupply",
+          outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+          stateMutability: "view",
+          type: "function",
+        },
       ],
       inheritedFunctions: {},
     },


### PR DESCRIPTION
## What

Shows the staked percentage of circulating supply and burned token count on the `/stake` page.

### Changes

**`deployedContracts.ts`** — Added `totalSupply()` to the production MockCLAWD ABI (chain 8453). It was missing from the partial ABI.

**`app/stake/page.tsx`:**
- Read `totalSupply()` and `balanceOf(0x...dEaD)` via `useScaffoldReadContract`
- Calculate `circulatingSupply = totalSupply - burnBalance`
- Calculate `stakedPct = (totalSupplyStaked / circulatingSupply) * 100`
- Updated the **Total Staked (All)** stat card to show:
  ```
  Total Staked (All)
  9,164.45M (12.4%)
  🔥 1.26B burned
  ```

### Self-Audit
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] ESLint passes (lint-staged)
- [x] No unused variables
- [x] Uses `useScaffoldReadContract` (not raw wagmi) for type safety
- [x] `useMemo` for derived calculations — no re-render waste
- [x] Graceful null handling — shows original UI when data not yet loaded
- [x] Percentage formatted to 1 decimal place
- [x] Burned amount formatted with B/M suffixes
- [x] No deployment — PR only